### PR TITLE
fix: update title to not have markdown backticks

### DIFF
--- a/content/html-page-lang-b5c3f8.md
+++ b/content/html-page-lang-b5c3f8.md
@@ -1,5 +1,5 @@
 ---
-title: "HTML page has `lang` attribute"
+title: "HTML page has lang attribute"
 permalink: /standards-guidelines/act/rules/html-page-lang-b5c3f8/
 ref: /standards-guidelines/act/rules/html-page-lang-b5c3f8/
 lang: en


### PR DESCRIPTION
The [wai-website-theme](https://github.com/w3c/wai-website-theme) does not process title in frontmatter via the markdown processor.

Closes Issue: 
- NA