### PR TITLE
Update w3c/wcag default branch

### DIFF
--- a/.github/workflows/copy-rules-to-wcag.yml
+++ b/.github/workflows/copy-rules-to-wcag.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       SOURCE_FILENAME: wcag-mapping.json
       DESTINATION_REPO: w3c/wcag
-      DESTINATION_BRANCH: master
+      DESTINATION_BRANCH: main
       DESTINATION_FILENAME: guidelines/act-mapping.json
       COMMIT_MESSAGE: ACT rules update from https://github.com/${{ github.repository }}/commit/${{ github.sha }}
     steps:


### PR DESCRIPTION
Apparently someone decided to rename the default branch on `w3c/wcag`. This broke our update script, so had to fix it.