### PR TITLE
Remove "under development" banner from homepage

### DIFF
--- a/_layouts/act_implementation.html
+++ b/_layouts/act_implementation.html
@@ -7,10 +7,6 @@ layout: standalone_resource
 {%- assign implementation = implementations[page.implementation_key] %}
 {%- assign implementationInfo = site.data.wcag-act-rules.act-implementations | where: "uniqueKey", page.implementation_key | first %}
 
-<section class="doc-note-box act-sticky">
-  <p>This page is <strong>under development</strong> and has not been approved by the working group.</p>
-</section>
-
 <aside class="box"> 
   <header class="box-h box-h-icon"> 
     Implementation Summary 

--- a/content/about.md
+++ b/content/about.md
@@ -12,10 +12,6 @@ github:
   path: content/about.md
 ---
 
-<section class="doc-note-box act-sticky">
-  <p>This page is <strong>under development</strong> and has not been approved by the working group.</p>
-</section>
-
 {::nomarkdown}
 {% include box.html type="start" title="Summary" class="" %}
 {:/}

--- a/content/about.md
+++ b/content/about.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: standalone_resource
 title: "About ACT Rules"
 permalink: /standards-guidelines/act/rules/about/

--- a/content/implementations.md
+++ b/content/implementations.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: standalone_resource
 title: "ACT Rules Implementation in Test Tools and Methodologies"
 permalink: /standards-guidelines/act/implementations/
@@ -14,10 +13,6 @@ github:
 
 {%- assign siteData = site.data.wcag-act-rules %}
 {%- assign implementations = siteData.act-implementations | sort: "name" %}
-
-<section class="doc-note-box act-sticky">
-  <p>This page is <strong>under development</strong> and has not been approved by the working group.</p>
-</section>
 
 {::nomarkdown} {% include box.html type="start" title="Summary" %} {:/}
 The tables on these pages show how many ACT Rules different accessibility test tools and methodologies have "consistently implemented". Each implementation links to a report with more details on how rules are implemented. See [understanding ACT consistency](#understanding-act-consistency) for details.

--- a/content/implementations/alfa.md
+++ b/content/implementations/alfa.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: act_implementation
 title: "Alfa ACT Implementation"
 permalink: /standards-guidelines/act/implementations/alfa/

--- a/content/implementations/axe-core.md
+++ b/content/implementations/axe-core.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: act_implementation
 title: "Axe-core ACT Implementation"
 permalink: /standards-guidelines/act/implementations/axe-core/

--- a/content/implementations/axe-devtools-pro.md
+++ b/content/implementations/axe-devtools-pro.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: act_implementation
 title: "Axe DevTools Pro ACT Implementation"
 permalink: /standards-guidelines/act/implementations/axe-devtools-pro/

--- a/content/implementations/equal-access.md
+++ b/content/implementations/equal-access.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: act_implementation
 title: "Equal Access Accessibility Checker ACT Implementation"
 permalink: /standards-guidelines/act/implementations/equal-access/

--- a/content/implementations/qualweb.md
+++ b/content/implementations/qualweb.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: act_implementation
 title: "QualWeb ACT Implementation"
 permalink: /standards-guidelines/act/implementations/qualweb/

--- a/content/implementations/sortsite.md
+++ b/content/implementations/sortsite.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: act_implementation
 title: "SortSite ACT Implementation"
 permalink: /standards-guidelines/act/implementations/sortsite/

--- a/content/implementations/trusted-tester.md
+++ b/content/implementations/trusted-tester.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: act_implementation
 title: "Trusted Tester ACT Implementation"
 permalink: /standards-guidelines/act/implementations/trusted-tester/

--- a/content/index.md
+++ b/content/index.md
@@ -12,10 +12,6 @@ github:
   path: content/index.md
 ---
 
-<section class="doc-note-box act-sticky">
-  <p>This page is <strong>under development</strong> and has not been approved by the working group.</p>
-</section>
-
 {::nomarkdown}
 {% include box.html type="start" title="Summary" class="" %}
 {:/}

--- a/content/index.md
+++ b/content/index.md
@@ -1,5 +1,4 @@
 ---
-doc-note-type: draft
 layout: standalone_resource
 title: "All ACT Rules"
 permalink: /standards-guidelines/act/rules/


### PR DESCRIPTION
This banner should have been removed months ago. This page was fully approved by AGWG ages ago. It's the implementations page that is still underdevelopment.