### PR TITLE
footer

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -9,6 +9,9 @@ footer: ""
 github:
   repository: w3c/wcag-act-rules
   path: content/about.md
+footer:
+  <p>ACT Rules are developed by the <a href="https://www.w3.org/community/act-r/">ACT Rules Community Group</a> and the <a href="https://www.w3.org/groups/tf/wcag-act">Accessibility Conformance Testing (ACT) Task Force</a> of the Accessibility Guidelines Working Group (<a href="https://www.w3.org/groups/wg/ag">AG WG</a>). ACT Rules work was part of the <a href="https://www.w3.org/WAI/about/projects/wai-tools/">WAI-Tools Project</a>, <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a>, and <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP Project</a>, co-funded by the European Commission.</p>  
+  
 ---
 
 {::nomarkdown}

--- a/content/index.md
+++ b/content/index.md
@@ -10,7 +10,8 @@ github:
   repository: w3c/wcag-act-rules
   path: content/index.md
 footer:
-  <p>This work was supported by the EC-funded <a href="https://www.w3.org/WAI/about/projects/wai-tools/">WAI-Tools Project</a> and <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a>.
+  <p>ACT Rules are developed by the <a href="https://www.w3.org/community/act-r/">ACT Rules Community Group</a> and the <a href="https://www.w3.org/groups/tf/wcag-act">Accessibility Conformance Testing (ACT) Task Force</a> of the Accessibility Guidelines Working Group (<a href="https://www.w3.org/groups/wg/ag">AG WG</a>). ACT Rules work was part of the <a href="https://www.w3.org/WAI/about/projects/wai-tools/">WAI-Tools Project</a>, <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a>, and <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP Project</a>, co-funded by the European Commission.</p>
+  
 ---
 
 {::nomarkdown}


### PR DESCRIPTION
Hi @wilco and @iadawn WAI standard footer text (from [template](https://raw.githubusercontent.com/w3c/wai-resource-template/main/content/index.md)) is:
```footer: >
   <p><strong>Date:</strong> Updated @@ Month 2021. First published Month 20@@. CHANGELOG.</p>
   <p><strong>Editors:</strong> @@name, @@name. Contributors: @@name, @@name, and <a href="https://www.w3.org/groups/wg/@@wg/participants">participants of the @@WG</a>. ACKNOWLEDGEMENTS lists contributors and credits.</p>
   <p>Developed by the @@ Working Group (<a href="http://www.w3.org/WAI/@@/">@@WG</a>). Developed as part of the <a href="https://www.w3.org/WAI/@@/">WAI-@@ project</a>, @@co-funded by the European Commission.</p>
```
To get the project acks on there today, see my suggestion at https://deploy-preview-206--wai-wcag-act-rules.netlify.app/standards-guidelines/act/rules/#wai-site-footer