### PR TITLE
Hide Fork/Issues links in feedback box

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,8 @@ defaults:
       rule_meta:
         rule_type: "Atomic rule"
       sidebar: true
+      github:
+        hide: true
       ## @@@ IMPORTANT @@@: Change to the config file need to be manually copied over to the WAI website
       standalone_resource_header:
         title: ACT Rules


### PR DESCRIPTION
The GitHub-related links in the feeback box ("Fork & Edit on GitHub" and "New GitHub Issue") point to the wrong repository, and are redundant with the "Useful links" section in the proposed rules.

This pull request hides the GitHub-related links to only display the "Email" link.