### PR TITLE
Copy to the Evaluation Tools List the updates merged to the publication branch

### DIFF
--- a/.github/workflows/copy-to-evaluation-tools-list.yml
+++ b/.github/workflows/copy-to-evaluation-tools-list.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: publication
           path: act-rules
 
       - name: Clone ${{ env.DESTINATION_REPO }}


### PR DESCRIPTION
The current `copy-to-evaluation-tools-list` workflow automatically copies to the Evaluation Tools list the ACT updates merged to the default branch (`main`). But changes made to the `main` branch are not yet published.

For example, https://github.com/w3c/wai-evaluation-tools-list/commit/495171382cb27a8fbe7decdf25ff3ec73a350ae8 contains changes still under review in https://github.com/w3c/wcag-act-rules/pull/339.

This could result in tool results in the Evaluation Tools list being ahead of those presented in the ACT Rules implementation reports.

This PR only applies changes merged to the `publication` branch.