### PR TITLE
Add Useful links to approved rules

### DIFF
--- a/_layouts/act_rule.html
+++ b/_layouts/act_rule.html
@@ -163,7 +163,6 @@ layout: standalone_resource
 {%- endunless %}
 {%- endif %}
 
-{%- if ruleId and page.github.path contains "/proposed.md" %}
 <h2>Useful Links</h2>
 <ul>
   <li><a href="https://github.com/act-rules/act-rules.github.io/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+{{ ruleId }}+">
@@ -178,4 +177,3 @@ layout: standalone_resource
   </a></li>
   {%- endif %}
 </ul>
-{%- endif %}


### PR DESCRIPTION
Closes https://github.com/w3c/wcag-act-rules/issues/366

This came up briefly in ACT-R today. People find these links useful (surprise!) but can't find them. So I figured we'd have them on the approved rules. If it turns out people do start opening issues that were already resolved, maybe that's a sign we should be publishing approved rules more regularly. That's not a bad signal to get.