### PR TITLE
Update paths  and urls for terms examples

### DIFF
--- a/content/terms/accessible-name/examples-of-accessible-name.md
+++ b/content/terms/accessible-name/examples-of-accessible-name.md
@@ -1,14 +1,14 @@
 ---
 layout: standalone_resource
 title: Examples of Accessible name
-permalink: /standards-guidelines/act/rules/examples/accessible-name/
-ref: /standards-guidelines/act/rules/examples/accessible-name/
+permalink: /standards-guidelines/act/rules/terms/accessible-name/examples/
+ref: /standards-guidelines/act/rules/terms/accessible-name/examples/
 lang: en
 type_of_guidance: ""
 footer: ""
 github:
   repository: w3c/wcag-act-rules
-  path: content/examples/accessible-name.md
+  path: content/terms/accessible-name/examples-of-accessible-name.md
 footer:
   <p>ACT Rules are developed by the <a href="https://www.w3.org/community/act-r/">ACT Rules Community Group</a> and the <a href="https://www.w3.org/groups/tf/wcag-act">Accessibility Conformance Testing (ACT) Task Force</a> of the Accessibility Guidelines Working Group (<a href="https://www.w3.org/groups/wg/ag">AG WG</a>). ACT Rules work was part of the <a href="https://www.w3.org/WAI/about/projects/wai-tools/">WAI-Tools Project</a>, <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a>, and <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP Project</a>, co-funded by the European Commission.</p>  
 ---

--- a/content/terms/element-language/examples-of-element-language.md
+++ b/content/terms/element-language/examples-of-element-language.md
@@ -1,14 +1,14 @@
 ---
 layout: standalone_resource
 title: Examples of Common and Default Language of an Element
-permalink: /standards-guidelines/act/rules/examples/element-language/
-ref: /standards-guidelines/act/rules/examples/element-language/
+permalink: /standards-guidelines/act/rules/terms/element-language/examples/
+ref: /standards-guidelines/act/rules/terms/element-language/examples/
 lang: en
 type_of_guidance: ""
 footer: ""
 github:
   repository: w3c/wcag-act-rules
-  path: content/examples/element-language.md
+  path: content/terms/element-language/examples-of-element-language.md
 footer:
   <p>ACT Rules are developed by the <a href="https://www.w3.org/community/act-r/">ACT Rules Community Group</a> and the <a href="https://www.w3.org/groups/tf/wcag-act">Accessibility Conformance Testing (ACT) Task Force</a> of the Accessibility Guidelines Working Group (<a href="https://www.w3.org/groups/wg/ag">AG WG</a>). ACT Rules work was part of the <a href="https://www.w3.org/WAI/about/projects/wai-tools/">WAI-Tools Project</a>, <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a>, and <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP Project</a>, co-funded by the European Commission.</p>  
 ---

--- a/content/terms/included-in-the-accessibility-tree/examples-of-included-in-the-accessibility-tree.md
+++ b/content/terms/included-in-the-accessibility-tree/examples-of-included-in-the-accessibility-tree.md
@@ -1,14 +1,14 @@
 ---
 layout: standalone_resource
 title: Examples of Included in the accessibility tree
-permalink: /standards-guidelines/act/rules/examples/included-in-the-accessibility-tree/
-ref: /standards-guidelines/act/rules/examples/included-in-the-accessibility-tree/
+permalink: /standards-guidelines/act/rules/terms/included-in-the-accessibility-tree/examples/
+ref: /standards-guidelines/act/rules/terms/included-in-the-accessibility-tree/examples/
 lang: en
 type_of_guidance: ""
 footer: ""
 github:
   repository: w3c/wcag-act-rules
-  path: content/examples/included-in-the-accessibility-tree.md
+  path: content/terms/included-in-the-accessibility-tree/examples-of-included-in-the-accessibility-tree.md
 footer:
   <p>ACT Rules are developed by the <a href="https://www.w3.org/community/act-r/">ACT Rules Community Group</a> and the <a href="https://www.w3.org/groups/tf/wcag-act">Accessibility Conformance Testing (ACT) Task Force</a> of the Accessibility Guidelines Working Group (<a href="https://www.w3.org/groups/wg/ag">AG WG</a>). ACT Rules work was part of the <a href="https://www.w3.org/WAI/about/projects/wai-tools/">WAI-Tools Project</a>, <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a>, and <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP Project</a>, co-funded by the European Commission.</p>  
 ---

--- a/content/terms/programmatic-label/examples-of-programmatic-label.md
+++ b/content/terms/programmatic-label/examples-of-programmatic-label.md
@@ -1,14 +1,14 @@
 ---
 layout: standalone_resource
 title: Examples of Programmatic label
-permalink: /standards-guidelines/act/rules/examples/programmatic-label/
-ref: /standards-guidelines/act/rules/examples/programmatic-label/
+permalink: /standards-guidelines/act/rules/terms/programmatic-label/examples/
+ref: /standards-guidelines/act/rules/terms/programmatic-label/examples/
 lang: en
 type_of_guidance: ""
 footer: ""
 github:
   repository: w3c/wcag-act-rules
-  path: content/examples/programmatic-label.md
+  path: content/terms/programmatic-label/examples-of-programmatic-label.md
 footer:
   <p>ACT Rules are developed by the <a href="https://www.w3.org/community/act-r/">ACT Rules Community Group</a> and the <a href="https://www.w3.org/groups/tf/wcag-act">Accessibility Conformance Testing (ACT) Task Force</a> of the Accessibility Guidelines Working Group (<a href="https://www.w3.org/groups/wg/ag">AG WG</a>). ACT Rules work was part of the <a href="https://www.w3.org/WAI/about/projects/wai-tools/">WAI-Tools Project</a>, <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a>, and <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP Project</a>, co-funded by the European Commission.</p>  
 ---

--- a/content/terms/visible/visible.md
+++ b/content/terms/visible/visible.md
@@ -1,14 +1,14 @@
 ---
 layout: standalone_resource
 title: Examples of Visible
-permalink: /standards-guidelines/act/rules/examples/visible/
-ref: /standards-guidelines/act/rules/examples/visible/
+permalink: /standards-guidelines/act/rules/terms/visible/examples/
+ref: /standards-guidelines/act/rules/terms/visible/examples/
 lang: en
 type_of_guidance: ""
 footer: ""
 github:
   repository: w3c/wcag-act-rules
-  path: content/examples/visible.md
+  path: content/terms/visible/examples-of-visible.md
 footer:
   <p>ACT Rules are developed by the <a href="https://www.w3.org/community/act-r/">ACT Rules Community Group</a> and the <a href="https://www.w3.org/groups/tf/wcag-act">Accessibility Conformance Testing (ACT) Task Force</a> of the Accessibility Guidelines Working Group (<a href="https://www.w3.org/groups/wg/ag">AG WG</a>). ACT Rules work was part of the <a href="https://www.w3.org/WAI/about/projects/wai-tools/">WAI-Tools Project</a>, <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a>, and <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP Project</a>, co-funded by the European Commission.</p>  
 ---


### PR DESCRIPTION
@remibetin

This updates the URLs and paths for the manually added terms examples, in response to [Rémi's comment](https://github.com/w3c/wcag-act-rules/pull/381#issuecomment-3744119108)