### PR TITLE
Fix broken links in term definition examples

### DIFF
--- a/content/terms/accessible-name/examples-of-accessible-name.md
+++ b/content/terms/accessible-name/examples-of-accessible-name.md
@@ -66,7 +66,7 @@ The `button` element has an accessible name of "Share ACT rules" given by the as
 
 ## Using text content
 
-This `a` element has an accessible name of "ACT rules" given from its content. Note that not all [semantic roles](#semantic-role) allow [name from content](https://www.w3.org/TR/wai-aria/#namefromcontent).
+This `a` element has an accessible name of "ACT rules" given from its content. Note that not all [semantic roles][] allow [name from content](https://www.w3.org/TR/wai-aria/#namefromcontent).
 
 ```html
 <a href="https://act-rules.github.io/">ACT rules</a>
@@ -96,7 +96,7 @@ This `span` element has an empty accessible name (`""`) because `span` is not a 
 
 ### Accessible name {#accessible-name}
 
-The _accessible name_ is the programmatically determined name of a user interface element that is [included in the accessibility tree](#included-in-the-accessibility-tree).
+The _accessible name_ is the programmatically determined name of a user interface element that is [included in the accessibility tree][].
 
 The accessible name is calculated using the [accessible name and description computation][].
 
@@ -106,5 +106,8 @@ For native markup languages, such as HTML and SVG, additional information on how
 
 **Note:** As per the [accessible name and description computation][], accessible names are [flat string](https://www.w3.org/TR/accname-1.1/#terminology) trimmed of leading and trailing whitespace. Notably, it is not possible for a non-empty accessible name to be composed only of whitespace since these must be trimmed.
 
+[accessible name]: #accessible-name
 [accessible name and description computation]: https://www.w3.org/TR/accname 'Accessible Name and Description Computation'
 [examples of accessible name]: https://act-rules.github.io/pages/examples/accessible-name/
+[included in the accessibility tree]: https://act-rules.github.io/glossary/#included-in-the-accessibility-tree
+[semantic roles]: https://act-rules.github.io/glossary/#semantic-role

--- a/content/terms/element-language/examples-of-element-language.md
+++ b/content/terms/element-language/examples-of-element-language.md
@@ -295,16 +295,15 @@ For more details, see [examples of visible](https://act-rules.github.io/pages/ex
 [tabindex value]: https://html.spec.whatwg.org/#tabindex-value
 [test subject]: https://www.w3.org/TR/act-rules-format-1.1/#test-subject
 [test target]: https://www.w3.org/TR/act-rules-format/#test-target
-[text inheriting its programmatic language]: #text-inheriting-language:text 'Definition of Text Inheriting its Programmatic Language from an Element'
+[text inheriting its programmatic language]: #text-inheriting-language 'Definition of Text Inheriting its Programmatic Language from an Element'
 [text nodes]: https://dom.spec.whatwg.org/#text 'DOM text, as of 2020/06/05'
 [top-level browsing context]: https://html.spec.whatwg.org/#top-level-browsing-context 'HTML top-level browsing context, as of 2020/06/05'
 [type field]: https://www.rfc-editor.org/rfc/rfc5646.html#section-3.1.3
 [usc312]: https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts.html 'Understanding Success Criterion 3.1.2: Language of Parts'
 [visible]: #visible 'Definition of Visible'
 [wai-aria specification]: https://www.w3.org/TR/wai-aria-1.2/#propcharacteristic_value 'WAI-ARIA Specification of States and Properties Value'
-[most common language]: /glossary/#most-common-element-language 'Definition of Common Language of an Element'
-[default language]: /glossary/#default-page-language 'Definition of Default Page Language'
+[default language]: https://act-rules.github.io/glossary/#default-page-language 'Definition of Default Page Language'
 [document element]: https://dom.spec.whatwg.org/#document-element 'DOM definition of Document Element'
-[element inheriting its programmatic language]: /glossary/#text-inheriting-language 'Definition of Element Inheriting its Programmatic Language From an Element'
-[elements inheriting their programmatic language]: /glossary/#text-inheriting-language 'Definition of Elements Inheriting their Programmatic Language from an Element'
-[text inheriting its programmatic language]: /glossary/#text-inheriting-language 'Definition of Text Inheriting its Programmatic Language from an Element'
+[element inheriting its programmatic language]: #text-inheriting-language 'Definition of Element Inheriting its Programmatic Language From an Element'
+[elements inheriting their programmatic language]: #text-inheriting-language 'Definition of Elements Inheriting their Programmatic Language from an Element'
+[text inheriting its programmatic language]: #text-inheriting-language 'Definition of Text Inheriting its Programmatic Language from an Element'

--- a/content/terms/included-in-the-accessibility-tree/examples-of-included-in-the-accessibility-tree.md
+++ b/content/terms/included-in-the-accessibility-tree/examples-of-included-in-the-accessibility-tree.md
@@ -100,10 +100,9 @@ Content perceivable through sight.
 
 Content is considered _visible_ if making it fully transparent would result in a difference in the pixels rendered for any part of the document that is currently within the viewport or can be brought into the viewport via scrolling.
 
-
 [accessible name]: #accessible-name
 [focusable]: #focusable
-[included in the accessibility tree]: /glossary/#included-in-the-accessibility-tree
+[included in the accessibility tree]: https://act-rules.github.io/glossary/#included-in-the-accessibility-tree
 [visible]: #visible
 [sequential focus navigation]: https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation
 [tabindex value]: https://html.spec.whatwg.org/#tabindex-value

--- a/content/terms/programmatic-label/examples-of-programmatic-label.md
+++ b/content/terms/programmatic-label/examples-of-programmatic-label.md
@@ -87,6 +87,6 @@ Element L is a _programmatic label_ of target element T if either:
 
 **Note**: a given element may have more than one programmatic label.
 
-[programmatic label]: /glossary/#programmatic-label
+[programmatic label]: #programmatic-label
 [labelable]: https://html.spec.whatwg.org/multipage/forms.html#category-label 'Definition of labelable elements'
 [labeled control]: https://html.spec.whatwg.org/multipage/forms.html#labeled-control 'Definition of labeled control'

--- a/content/terms/visible/visible.md
+++ b/content/terms/visible/visible.md
@@ -136,4 +136,4 @@ Content perceivable through sight.
 
 Content is considered _visible_ if making it fully transparent would result in a difference in the pixels rendered for any part of the document that is currently within the viewport or can be brought into the viewport via scrolling.
 
-[visible]: /glossary/#visible
+[visible]: #visible


### PR DESCRIPTION
This PR fixes the broken links in the term definition examples pages:
- When the definition is expanded on the same page, I've used a fragment link to point to that section.
- Otherwise, I've pointed to the definition in the [act-rules.github.io glossary](https://act-rules.github.io/glossary/).