### PR TITLE
Update to versions of actions that support Node.js 24

### DIFF
--- a/.github/workflows/copy-rules-to-wcag.yml
+++ b/.github/workflows/copy-rules-to-wcag.yml
@@ -30,7 +30,7 @@ jobs:
       COMMIT_MESSAGE: ACT rules update from https://github.com/${{ github.repository }}/commit/${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: this
           

--- a/.github/workflows/copy-to-evaluation-tools-list.yml
+++ b/.github/workflows/copy-to-evaluation-tools-list.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: publication
           path: act-rules


### PR DESCRIPTION
Related to https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

