### PR TITLE
Restore transcripts of the moon speech

### DIFF
--- a/content-assets/wcag-act-rules/test-assets/moon-audio/moon-speech-incorrect-transcript.txt
+++ b/content-assets/wcag-act-rules/test-assets/moon-audio/moon-speech-incorrect-transcript.txt
@@ -1,0 +1,13 @@
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>Transcript of the moon speech</title>
+</head>
+<body>
+
+<p>The above audio contains the following speech: We choose to go to the cheese in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
+
+</body>

--- a/content-assets/wcag-act-rules/test-assets/moon-audio/moon-speech-transcript.txt
+++ b/content-assets/wcag-act-rules/test-assets/moon-audio/moon-speech-transcript.txt
@@ -1,0 +1,13 @@
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>Transcript of the moon speech</title>
+</head>
+<body>
+
+<p>The above audio contains the following speech: We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
+
+</body>


### PR DESCRIPTION
These files seem to have been accidentally removed by https://github.com/w3c/wcag-act-rules/pull/417/changes/28483c722686323788c0badc000a6d3f496e787e