### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/copy-rules-to-wcag.yml
+++ b/.github/workflows/copy-rules-to-wcag.yml
@@ -22,6 +22,8 @@ jobs:
   copy-rules:
     name: Copy rules
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       SOURCE_FILENAME: wcag-mapping.json
       DESTINATION_REPO: w3c/wcag
@@ -30,7 +32,7 @@ jobs:
       COMMIT_MESSAGE: ACT rules update from https://github.com/${{ github.repository }}/commit/${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
           path: this
           

--- a/.github/workflows/copy-to-evaluation-tools-list.yml
+++ b/.github/workflows/copy-to-evaluation-tools-list.yml
@@ -13,6 +13,8 @@ jobs:
   copy-rules:
     name: Copy Implementation Data
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       SOURCE_DIR: _data/wcag-act-rules/implementations
       DESTINATION_REPO: w3c/wai-evaluation-tools-list
@@ -21,14 +23,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
           ref: publication
           path: act-rules
 
       - name: Clone ${{ env.DESTINATION_REPO }}
         env:
-          W3CGRUNTBOT_TOKEN: ${{ secrets.W3CGRUNTBOT_TOKEN }} # add as PAT (https://github.com/settings/tokens) as a secret
+          W3CGRUNTBOT_TOKEN: ${{ secrets.W3CGRUNTBOT_TOKEN }}
         run: |
           echo "Cloning $DESTINATION_REPO git repository"
           git clone --single-branch --branch $DESTINATION_BRANCH "https://$W3CGRUNTBOT_TOKEN@github.com/$DESTINATION_REPO.git" evaluation-tools

--- a/.github/workflows/implementation-update.yml
+++ b/.github/workflows/implementation-update.yml
@@ -8,22 +8,28 @@ on:
 jobs:
   implementation-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v6
-        with:
-          token: '${{ secrets.W3CGRUNTBOT_TOKEN }}'
-      - uses: actions/setup-node@v6
+      - name: Checkout the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
         with:
           node-version: '24'
-      - uses: actions/cache@v5
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: "node_modules"
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
+
       - run: node ./.github/scripts/implementation-update.mjs
+
       - name: Commit and push
         run: |
-          git config user.name w3cgruntbot
-          git config user.email w3cgruntbot@users.noreply.github.com
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           npx zx ./.github/scripts/commit-and-push.mjs

--- a/.github/workflows/pr-to-publish.yml
+++ b/.github/workflows/pr-to-publish.yml
@@ -8,13 +8,13 @@ on:
 jobs:
   pr-to-publish:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
@@ -27,3 +27,5 @@ jobs:
             --reviewer kfranqueiro \
             --title "WAI website update ${{ steps.date.outputs.date }}" \
             --body "This is an automated pull request to publish ACT content to the WAI website."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR:
- pins actions to a full-length commit SHA, following GitHub's recommendations
- bumps `checkout` from v6 to v7.0.1
- bumps `setup-node` from v6 to v7.0.0
- bumps `cache` from v5 to v6.1.0
- sets more specific permissions
- updates implementations using GitHub Actions directly instead of a PAT

All workflows were tested successfully in forks.